### PR TITLE
promote coredns (test manifest list)

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,3 +6,6 @@ images:
 - name: hello-world
   dmap:
     "sha256:ec22e8de4b8d40252518147adfb76877cb5e1fa10293e52db26a9623c6a4e92b": ["1.0", "2.1"]
+- name: coredns
+  dmap:
+    "sha256:02382353821b12c21b062c59184e227e001079bb13ebd01f9d3270ba0fcbf1e4": ["1.3.1"] # Manifest list.


### PR DESCRIPTION
We might need to disable garbage collection (or make it smarter so that
tagless images that are referenced by manifest lists don't get deleted).